### PR TITLE
add `admin.tools` to permissions

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -862,6 +862,7 @@ class AdminPlugin extends Plugin
             'admin.statistics'    => 'boolean',
             'admin.plugins'       => 'boolean',
             'admin.themes'        => 'boolean',
+            'admin.tools'         => 'boolean',
             'admin.users'         => 'boolean',
         ];
         $admin->addPermissions($permissions);


### PR DESCRIPTION
So that an administrator can disable access to Direct Install of Grav Packages